### PR TITLE
Fixed test_slice_content

### DIFF
--- a/dosna/backends/base.py
+++ b/dosna/backends/base.py
@@ -225,7 +225,7 @@ class BackendDataset(object):
                                 ' slices are supported'.format(type(slice_)))
 
         if squeeze:
-            return final_slices, squeeze_axis
+            return final_slices, tuple(squeeze_axis)
         return final_slices
 
     @staticmethod


### PR DESCRIPTION
Numpy squeeze axis can only take ints or tuples so the processes slices returns a tuple on the axis instead of an array.