### PR TITLE
Removing deprecation warning from numpy fromstring

### DIFF
--- a/dosna/backends/ceph.py
+++ b/dosna/backends/ceph.py
@@ -174,7 +174,7 @@ class CephDataChunk(BackendDataChunk):
     def get_data(self, slices=None):
         if slices is None:
             slices = slice(None)
-        data = np.fromstring(self.read(), dtype=self.dtype, count=self.size)
+        data = np.frombuffer(self.read(), dtype=self.dtype, count=self.size).copy()
         data.shape = self.shape
         return data[slices]
 

--- a/dosna/backends/s3.py
+++ b/dosna/backends/s3.py
@@ -259,7 +259,7 @@ class S3DataChunk(BackendDataChunk):
     def get_data(self, slices=None):
         if slices is None:
             slices = slice(None)
-        data = np.fromstring(self.read(), dtype=self.dtype, count=self.size)
+        data = np.frombuffer(self.read(), dtype=self.dtype, count=self.size).copy()
         data.shape = self.shape
         return data[slices]
 


### PR DESCRIPTION
This change replaces the fromstring to frombuffer with a copy such that the data from the buffer mutable which is required.