### PR TITLE
Added Slice Check on int input

### DIFF
--- a/dosna/backends/base.py
+++ b/dosna/backends/base.py
@@ -284,8 +284,12 @@ class BackendDataset(object):
         squeeze_axis = []
         for index, slice_ in enumerate(slices):
             if isinstance(slice_, int):
-                final_slices.append(slice(slice_, slice_ + 1))
-                squeeze_axis.append(index)
+                if slice_ < shape[index]:
+                    final_slices.append(slice(slice_, slice_ + 1))
+                    squeeze_axis.append(index)
+                else:
+                    raise IndexError("index {} is out of bounds for axis {} with size {}"
+                                     .format(slice_, index, shape[index]))
             elif isinstance(slice_, slice):
                 start = slice_.start
                 stop = slice_.stop


### PR DESCRIPTION
This checks that the slice is smaller than the shape index value that it corresponds to. If it is within the bounds, everything works like usual.  However, if it is outside the bounds and IndexError is raised instead.